### PR TITLE
Fingerprint's trailing zeros exposed to JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Node native addon module (C/C++) for [Rabin fingerprinting](https://en.wikipedia
 
 Uses the implementation of Rabin fingerprinting from [LBFS](https://github.com/fd0/lbfs/tree/bdf4f17d23b68536e7805c88e269026c74c32d59/liblbfs).
 
-Rabin fingerprinting is useful for finding the chunks of a file that differ from a previous version. It's one implementation of a technique called "Content-defined chunking", meaning the chunk boundaries are determinstic to the content (as opposed to "fixed-sized chunking").
+Rabin fingerprinting is useful for finding the chunks of a file that differ from a previous version. It's one implementation of a technique called "Content-defined chunking", meaning the chunk boundaries are deterministic to the content (as opposed to "fixed-sized chunking").
 
 Theres a JavaScript API and an accompanying command-line tool.
 
@@ -50,4 +50,3 @@ $ rabin myfile.txt --bits=14 --min=8192 --max=32768 # defaults
 {"length":14947,"offset":85053,"hash":"4224e6f4361fa8bdefb9d8e10ebd046e2869af2c44ea7e84c7efaeedd5423b30"}
 average 12500
 ```
-

--- a/cli.js
+++ b/cli.js
@@ -7,14 +7,26 @@ var offset = 0
 var rs = fs.createReadStream(args._[0])
 var count = 0
 rs.pipe(rabin).on('data', function (ch) {
-  var hash = crypto.createHash('sha256').update(ch).digest('hex')
-  var data = {
-    length: ch.length,
-    offset: offset,
-    hash: hash
+  if (args.metadata) {
+    var hash = crypto.createHash('sha256').update(ch.buffer).digest('hex')
+    var data = {
+      length: ch.buffer.length,
+      offset: offset,
+      hash: hash,
+      trailingZeros: ch.trailingZeros
+    }
+    offset += ch.buffer.length
+  }
+  else {
+    var hash = crypto.createHash('sha256').update(ch).digest('hex')
+    var data = {
+      length: ch.length,
+      offset: offset,
+      hash: hash
+    }
+    offset += ch.length
   }
   console.log(JSON.stringify(data))
-  offset += ch.length
   count++
 }).on('end', function () {
   console.error('average', ~~(offset / count))

--- a/cli.js
+++ b/cli.js
@@ -7,15 +7,15 @@ var offset = 0
 var rs = fs.createReadStream(args._[0])
 var count = 0
 rs.pipe(rabin).on('data', function (ch) {
-  offset += ch.length
-  count++
   var hash = crypto.createHash('sha256').update(ch).digest('hex')
   var data = {
     length: ch.length,
-    offset: offset - ch.length,
+    offset: offset,
     hash: hash
   }
   console.log(JSON.stringify(data))
+  offset += ch.length
+  count++
 }).on('end', function () {
   console.error('average', ~~(offset / count))
 })

--- a/index.js
+++ b/index.js
@@ -15,11 +15,22 @@ function Rabin (opts) {
   var avgBits = +opts.bits || 12
   var min = +opts.min || 8 * 1024
   var max = +opts.max || 32 * 1024
+  this.metadata = opts.metadata ? true : false
   this.rabin = rabin.initialize(avgBits, min, max)
   this.nextCb = null
   this.buffers = new BufferList()
   this.on('finish', function () {
-    if (this.buffers.length) this.push(this.buffers.slice(0, this.buffers.length))
+    if (this.buffers.length) {
+      if (this.metadata) {
+        this.push({
+          buffer: this.buffers.slice(0, this.buffers.length),
+          trailingZeros: 0,
+        })
+      }
+      else {
+        this.push(this.buffers.slice(0, this.buffers.length))
+      }
+    }
     this.push(null)
     this.rabinEnd()
   })
@@ -43,13 +54,17 @@ Rabin.prototype._writev = function (batch, cb) {
     return chunk
   })
   var lengths = []
-  rabin.fingerprint(this.rabin, bufs, lengths)
+  var trailingZeros = []
+  rabin.fingerprint(this.rabin, bufs, lengths, trailingZeros)
   debug('chunks', lengths)
   for (var i = 0; i < lengths.length; i++) {
     var size = lengths[i]
     var buf = this.buffers.slice(0, size)
     this.buffers.consume(size)
-    drained = this.push(buf)
+    drained = this.push(this.metadata ? {
+        buffer: buf,
+        trailingZeros: trailingZeros[i]
+      } : buf)
   }
   if (drained) cb()
   else this.nextCb = cb


### PR DESCRIPTION
A fix for #4:

Exposed the fingerprint from the C module to the JS module, in the form of an integer representing the number of trailing zeros of the fingerprint.

The parameter is exposed when Rabin() is created with the option `{metadata: true}`.

Note: please review my line `this.metadata = opts.metadata ? true : false`, I am not sure if it needs to be implemented like that.
